### PR TITLE
Save the diagram to svg image

### DIFF
--- a/diagramsascode-image/src/main/java/org/diagramsascode/image/Image.java
+++ b/diagramsascode-image/src/main/java/org/diagramsascode/image/Image.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Objects;
 
+import net.sourceforge.plantuml.FileFormat;
+import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.SourceStringReader;
 import net.sourceforge.plantuml.core.DiagramDescription;
 
@@ -53,7 +55,27 @@ public class Image {
    */
   public void writeToPngStream(OutputStream outputStream) {
     SourceStringReader reader = readerOf(imageSource);
-    writeImageToStream(reader, outputStream);
+    writeImageToStream(reader, outputStream, FileFormat.PNG);
+  }
+
+  /**
+   * Writes a SVG image file to the specified location.
+   *
+   * @param outputFile the file to write to
+   */
+  public void writeToSvgFile(File outputFile) {
+    FileOutputStream outputStream = outputStreamFor(outputFile);
+    writeToSvgStream(outputStream);
+  }
+
+  /**
+   * Writes a SVG image file to the specified stream.
+   *
+   * @param outputStream the stream to write to
+   */
+  public void writeToSvgStream(OutputStream outputStream) {
+    SourceStringReader reader = readerOf(imageSource);
+    writeImageToStream(reader, outputStream, FileFormat.SVG);
   }
 
   private SourceStringReader readerOf(ImageSource imageSource) {
@@ -61,10 +83,9 @@ public class Image {
     return new SourceStringReader(sourceString);
   }
 
-  private DiagramDescription writeImageToStream(SourceStringReader reader, OutputStream outputStream) {
+  private DiagramDescription writeImageToStream(SourceStringReader reader, OutputStream outputStream, FileFormat fileFormat) {
     try {
-      DiagramDescription desc = reader.outputImage(outputStream);
-      return desc;
+      return reader.outputImage(outputStream, 0, new FileFormatOption(fileFormat));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/diagramsascode-image/src/test/java/org/diagramsascode/image/ActivityDiagramImageTest.java
+++ b/diagramsascode-image/src/test/java/org/diagramsascode/image/ActivityDiagramImageTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 
 class ActivityDiagramImageTest { 
   @Test
-  void writesActivityDiagramImageToFile() throws IOException {
+  void writesActivityDiagramImageToFilePng() throws IOException {
     // Create the initial and final node (to define where the flow starts and ends)
     var initialNode = new InitialNode();
     var finalNode = new FinalNode();
@@ -55,6 +55,49 @@ class ActivityDiagramImageTest {
     var outputFile = File.createTempFile("activity", ".png");
     ActivityDiagramImage.of(diagram).writeToPngFile(outputFile);
     
+    System.out.println("Activity diagram written to: " + outputFile);
+    assertTrue(outputFile.exists());
+  }
+
+  @Test
+  void writesActivityDiagramImageToFileSvg() throws IOException {
+    // Create the initial and final node (to define where the flow starts and ends)
+    var initialNode = new InitialNode();
+    var finalNode = new FinalNode();
+
+    // Create the decision and merge node (to split the flow and merge it back together)
+    var decisionNode = new DecisionNode();
+    var mergeNode = new MergeNode();
+
+    // Create actions (for the flow steps)
+    var action1 = new Action("Action1");
+    var action2a = new Action("Action2a");
+    var action2b = new Action("Action2b");
+    var action3 = new Action("Action3");
+
+    // Connect the nodes with control flow edges.
+    // If they originate from a decision node, the third constructor parameter
+    // specifies the decision's condition (e.g. "x < 100")
+    var edge1 = new ControlFlow(initialNode, action1);
+    var edge2 = new ControlFlow(action1, decisionNode);
+    var edge3_a = new ControlFlow(decisionNode, action2a, "x < 100");
+    var edge3_b = new ControlFlow(decisionNode, action2b, "x >= 100");
+    var edge4_a = new ControlFlow(action2a, mergeNode);
+    var edge4_b = new ControlFlow(action2b, mergeNode);
+    var edge5 = new ControlFlow(mergeNode, action3);
+    var edge6 = new ControlFlow(action3, finalNode);
+
+    // Build the diagram
+    var diagram = Diagram.builder()
+      .withNodes(initialNode, finalNode, decisionNode, mergeNode, action1, action2a, action2b, action3)
+      .withEdges(edge1, edge2, edge3_a, edge3_b, edge4_a, edge4_b, edge5, edge6)
+      .withConstraints(new ActivityDiagramConstraints())
+      .build();
+
+    // Create the image of the diagram and write it to a SVG file.
+    var outputFile = File.createTempFile("activity", ".svg");
+    ActivityDiagramImage.of(diagram).writeToSvgFile(outputFile);
+
     System.out.println("Activity diagram written to: " + outputFile);
     assertTrue(outputFile.exists());
   }


### PR DESCRIPTION
## Description
The diagram can be saved just to `PNG` image. 
This change add the option to save to `SVG` image.

## Change
I created two methods in the `Image` class. They work as the methods to write png image.

`PNG` methods:
```java
public void writeToPngFile(File outputFile);
public void writeToPngStream(OutputStream outputStream);
```

`SVG` methods
```java
public void writeToSvgFile(File outputFile);
public void writeToSvgStream(OutputStream outputStream);
```

In order to handle both formats, I added `fileFormat` parameter to method `writeImageToStream` that is called by `writeToSvgStream` and `writeToPngStream`.

At the end in the class `ActivityDiagramImageTest`:
- I renamed `writesActivityDiagramImageToFile` to `writesActivityDiagramImageToFilePng`
- I added `writesActivityDiagramImageToFileSvg`